### PR TITLE
Now sending lobby updates to clients in the lobby

### DIFF
--- a/shithead_game_server/src/client_handler.rs
+++ b/shithead_game_server/src/client_handler.rs
@@ -226,6 +226,9 @@ pub async fn handle_client(
 
     let id = server_state.next_client_id();
 
+    // add the client to the list of connected clients.
+    server_state.add_client(id);
+
     let mut game_client = ClientHandler {
         websocket,
         client_id: id,

--- a/shithead_game_server/src/client_handler.rs
+++ b/shithead_game_server/src/client_handler.rs
@@ -207,6 +207,8 @@ impl ClientHandler {
             self.server_state
                 .remove_player_from_lobby(self.client_id, lobby_id);
         }
+
+        // then remove the client from the list of connected clients.
         self.server_state.remove_client(self.client_id);
         Ok(())
     }

--- a/shithead_game_server/src/game_server.rs
+++ b/shithead_game_server/src/game_server.rs
@@ -159,7 +159,7 @@ impl GameServerState {
                 // lobby isn't empty, so we still have listeners.
                 let _ = lobby
                     .broadcast_messages_sender
-                    .send(ServerMessage::OwnerLeftLobby { left_owner_id: player_id, new_owner_id });
+                    .send(ServerMessage::OwnerLeftLobby { new_owner_id });
             }
             RemovePlayerFromLobbyResult::LobbyNowEmpty => {
                 // the lobby is now empty, remove it

--- a/shithead_game_server/src/game_server.rs
+++ b/shithead_game_server/src/game_server.rs
@@ -112,7 +112,7 @@ impl GameServerState {
         }
 
         // get the username of the player.
-        // it's safe to unwrap here because there's no way that the player is not in the client 
+        // it's safe to unwrap here because there's no way that the player is not in the client
         // infos list. that's because the only place we remove it from the list is in the
         // `ClientHandler::cleanup` function, but there is no way this function is called after
         // the cleanup.
@@ -120,14 +120,16 @@ impl GameServerState {
 
         lobby.add_player(player_id);
 
-        if !lobby.is_empty(){
+        if !lobby.is_empty() {
             // if there are players in the lobby, let them know about the new client.
             // we can ignore the return value since we know it will be Ok(()), becuase the
             // lobby isn't empty, so we still have listeners
-            let _ = lobby.broadcast_messages_sender.send(ServerMessage::PlayerJoinedLobby(ExposedLobbyPlayerInfo{
-                id: player_id,
-                username,
-            }));
+            let _ = lobby
+                .broadcast_messages_sender
+                .send(ServerMessage::PlayerJoinedLobby(ExposedLobbyPlayerInfo {
+                    id: player_id,
+                    username,
+                }));
         }
 
         Ok(lobby.broadcast_messages_sender.clone())
@@ -172,6 +174,9 @@ impl GameServerState {
                 // the lobby is now empty, remove it
                 self.lobbies.remove(&lobby_id);
             }
+            RemovePlayerFromLobbyResult::PlayerWasntInLobby => {
+                // no need to notify anyone because the player wasn't even in the lobby
+            }
         }
     }
 
@@ -194,7 +199,7 @@ impl GameServerState {
                             })
                         })
                         .collect(),
-                        owner_id: lobby.owner_id(),
+                    owner_id: lobby.owner_id(),
                 }
             })
             .collect()
@@ -213,10 +218,13 @@ impl GameServerState {
     }
 
     /// Adds a new client to the list of connected clients, and generates a default username for it.
-    pub fn add_client(&self, client_id: ClientId){
-        self.client_infos.insert(client_id, ClientInfo{
-            username: format!("user{}", client_id),
-        });
+    pub fn add_client(&self, client_id: ClientId) {
+        self.client_infos.insert(
+            client_id,
+            ClientInfo {
+                username: format!("user{}", client_id),
+            },
+        );
     }
 
     /// Removes the client from the list of connected clients.

--- a/shithead_game_server/src/game_server.rs
+++ b/shithead_game_server/src/game_server.rs
@@ -194,6 +194,7 @@ impl GameServerState {
                             })
                         })
                         .collect(),
+                        owner_id: lobby.owner_id(),
                 }
             })
             .collect()
@@ -281,6 +282,7 @@ pub struct ExposedLobbyInfo {
     pub name: String,
     pub id: LobbyId,
     pub players: Vec<ExposedLobbyPlayerInfo>,
+    pub owner_id: ClientId,
 }
 
 /// The information about a lobby player that is exposed to the clients.

--- a/shithead_game_server/src/game_server.rs
+++ b/shithead_game_server/src/game_server.rs
@@ -212,6 +212,13 @@ impl GameServerState {
         client_info.username = new_username;
     }
 
+    /// Adds a new client to the list of connected clients, and generates a default username for it.
+    pub fn add_client(&self, client_id: ClientId){
+        self.client_infos.insert(client_id, ClientInfo{
+            username: format!("user{}", client_id),
+        });
+    }
+
     /// Removes the client from the list of connected clients.
     pub fn remove_client(&self, client_id: ClientId) {
         self.client_infos.remove(&client_id);

--- a/shithead_game_server/src/lobby.rs
+++ b/shithead_game_server/src/lobby.rs
@@ -125,10 +125,11 @@ impl Lobby {
     }
 
     /// The id of the owner.
-    pub fn owner_id(&self)->ClientId{
+    pub fn owner_id(&self) -> ClientId {
         self.owner_id
     }
 
+    /// The ids of the players in the lobby.
     pub fn player_ids<'a>(&'a self) -> impl Iterator<Item = ClientId> + 'a {
         self.players.iter().map(|entry| *entry.key())
     }
@@ -146,7 +147,9 @@ impl Lobby {
     /// Removes the player with the given id from the lobby, and moves make another player the
     /// owner.
     pub fn remove_player(&mut self, player_id: ClientId) -> RemovePlayerFromLobbyResult {
-        self.players.remove(&player_id);
+        if self.players.remove(&player_id).is_none() {
+            return RemovePlayerFromLobbyResult::PlayerWasntInLobby;
+        }
 
         // if the removed player was the owner
         if player_id == self.owner_id {
@@ -196,4 +199,5 @@ pub enum RemovePlayerFromLobbyResult {
     Ok,
     NewOwner(ClientId),
     LobbyNowEmpty,
+    PlayerWasntInLobby,
 }

--- a/shithead_game_server/src/lobby.rs
+++ b/shithead_game_server/src/lobby.rs
@@ -3,7 +3,10 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
-use crate::{game_server::{ClientId, BROADCAST_CHANNEL_CAPACITY}, messages::ServerMessage};
+use crate::{
+    game_server::{ClientId, BROADCAST_CHANNEL_CAPACITY},
+    messages::ServerMessage,
+};
 
 pub const MAX_PLAYERS_IN_LOBBY: usize = 6;
 
@@ -97,7 +100,7 @@ impl Lobby {
             name,
             deck,
             players,
-            broadcast_messages_sender
+            broadcast_messages_sender,
         }
     }
 
@@ -116,13 +119,18 @@ impl Lobby {
         &self.name
     }
 
+    pub fn player_ids<'a>(&'a self) -> impl Iterator<Item = ClientId> + 'a {
+        self.players.iter().map(|entry| *entry.key())
+    }
+
     /// Adds a player to the lobby without checking performing any checks.
     /// The checks are done in `GameServerState::join_lobby`.
     ///
     /// The player starts with no cards at all, since assuming checks have been done, the lobby
     /// should be in the `LobbyState::Waiting` state, in which no players have cards.
     pub fn add_player(&self, player_id: ClientId) {
-        self.players.insert(player_id, LobbyPlayer::without_any_cards());
+        self.players
+            .insert(player_id, LobbyPlayer::without_any_cards());
     }
 
     /// Removes the player with the given id from the lobby, and moves make another player the

--- a/shithead_game_server/src/lobby.rs
+++ b/shithead_game_server/src/lobby.rs
@@ -109,6 +109,11 @@ impl Lobby {
         self.players.len()
     }
 
+    /// Is the lobby empty?
+    pub fn is_empty(&self) -> bool {
+        self.players.is_empty()
+    }
+
     /// The current state of the lobby.
     pub fn state(&self) -> LobbyState {
         self.state

--- a/shithead_game_server/src/lobby.rs
+++ b/shithead_game_server/src/lobby.rs
@@ -77,7 +77,7 @@ pub struct Lobby {
     name: String,
     state: LobbyState,
     deck: DashSet<CardId>,
-    owner: ClientId,
+    owner_id: ClientId,
     players: DashMap<ClientId, LobbyPlayer>,
     pub broadcast_messages_sender: broadcast::Sender<ServerMessage>,
 }
@@ -96,7 +96,7 @@ impl Lobby {
         let (broadcast_messages_sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
         Self {
             state: LobbyState::Waiting,
-            owner: owner_id,
+            owner_id,
             name,
             deck,
             players,
@@ -124,6 +124,11 @@ impl Lobby {
         &self.name
     }
 
+    /// The id of the owner.
+    pub fn owner_id(&self)->ClientId{
+        self.owner_id
+    }
+
     pub fn player_ids<'a>(&'a self) -> impl Iterator<Item = ClientId> + 'a {
         self.players.iter().map(|entry| *entry.key())
     }
@@ -144,7 +149,7 @@ impl Lobby {
         self.players.remove(&player_id);
 
         // if the removed player was the owner
-        if player_id == self.owner {
+        if player_id == self.owner_id {
             match self.players.iter().next() {
                 None => {
                     // if there are no players left
@@ -152,7 +157,7 @@ impl Lobby {
                 }
                 Some(new_owner_entry) => {
                     let new_owner_id = *new_owner_entry.key();
-                    self.owner = new_owner_id;
+                    self.owner_id = new_owner_id;
                     RemovePlayerFromLobbyResult::NewOwner(new_owner_id)
                 }
             }

--- a/shithead_game_server/src/messages.rs
+++ b/shithead_game_server/src/messages.rs
@@ -21,8 +21,9 @@ pub enum ServerMessage {
         new_owner_id: ClientId,
     },
 
+    // don't need the id of the previous owner because all the clients already know who the owner
+    // is.
     OwnerLeftLobby {
-        left_owner_id: ClientId,
         new_owner_id: ClientId,
     },
 

--- a/shithead_game_server/src/messages.rs
+++ b/shithead_game_server/src/messages.rs
@@ -15,8 +15,16 @@ pub enum ServerMessage {
     PlayerJoinedLobby(ExposedLobbyPlayerInfo),
     PlayerLeftLobby(ClientId),
 
+    // reserved for future use
     #[serde(rename_all = "camelCase")]
-    LobbyOwnerChanged{ new_owner: ClientId },
+    LobbyOwnerChanged {
+        new_owner_id: ClientId,
+    },
+
+    OwnerLeftLobby {
+        left_owner_id: ClientId,
+        new_owner_id: ClientId,
+    },
 
     ClickCard(ClickedCardLocation),
 }

--- a/shithead_game_server/src/messages.rs
+++ b/shithead_game_server/src/messages.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    game_server::{ClientId, ExposedLobbyInfo},
+    game_server::{ClientId, ExposedLobbyInfo, ExposedLobbyPlayerInfo},
     lobby::LobbyId,
 };
 
@@ -12,6 +12,12 @@ pub enum ServerMessage {
     Lobbies(Vec<ExposedLobbyInfo>),
     JoinLobby(LobbyId),
     Error(String),
+    PlayerJoinedLobby(ExposedLobbyPlayerInfo),
+    PlayerLeftLobby(ClientId),
+
+    #[serde(rename_all = "camelCase")]
+    LobbyOwnerChanged{ new_owner: ClientId },
+
     ClickCard(ClickedCardLocation),
 }
 


### PR DESCRIPTION
The lobby updates currently contain the following messages:
 - a player joined the lobby
 - a player left the lobby
 - the lobby's owner changed